### PR TITLE
fix: add pytest timeout and CI job timeout to prevent hanging tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# Global owners
+* @Linnnnberg
+
+# Critical files require review
+pyproject.toml @Linnnnberg
+.github/workflows/ @Linnnnberg
+README.md @Linnnnberg
+CHANGELOG.md @Linnnnberg
+
+# Core code requires review
+pysee/ @Linnnnberg
+tests/ @Linnnnberg
+examples/ @Linnnnberg
+
+# Documentation requires review
+docs/ @Linnnnberg
+*.md @Linnnnberg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']  # Full Python version matrix
@@ -58,7 +59,8 @@ jobs:
 
     - name: Test with pytest
       run: |
-        pytest test_pysee.py -v
+        pytest test_pysee.py -v --timeout=60
+        pytest tests/ -v --timeout=60 --maxfail=3
 
     - name: Test example script
       run: |

--- a/JUPYTER_INTEGRATION_PLAN.md
+++ b/JUPYTER_INTEGRATION_PLAN.md
@@ -1,0 +1,339 @@
+# 📓 PySEE Jupyter Integration Enhancement Plan
+
+## **🔍 Current Status Analysis**
+
+### **✅ What We Have:**
+- **Basic Plotly Integration**: Figures display in Jupyter notebooks
+- **ipywidgets Dependency**: Listed in requirements.txt
+- **Simple Display**: `fig.show()` works in notebooks
+- **Code Export**: Reproducible Python snippets
+
+### **❌ What We're Missing:**
+- **Proper Widget Integration**: No actual Jupyter widgets
+- **Interactive Controls**: No widget-based configuration panels
+- **State Management**: No widget state persistence
+- **Notebook-Specific Features**: No Jupyter optimizations
+
+---
+
+## **🎯 Enhancement Plan**
+
+### **Phase 1: Basic Widget Integration (1-2 days)**
+**Priority: HIGH | Effort: 1-2 days | Impact: HIGH**
+
+#### **1.1 Create PySEEWidget Class**
+```python
+# pysee/widgets/dashboard_widget.py
+import ipywidgets as widgets
+from IPython.display import display
+from ..core.dashboard import PySEE
+
+class PySEEWidget:
+    """Jupyter widget wrapper for PySEE dashboard."""
+    
+    def __init__(self, adata, title="PySEE Dashboard"):
+        self.dashboard = PySEE(adata, title)
+        self._create_widgets()
+        self._setup_callbacks()
+    
+    def _create_widgets(self):
+        """Create interactive widgets."""
+        # Panel selection dropdown
+        self.panel_selector = widgets.Dropdown(
+            options=list(self.dashboard._panels.keys()),
+            description='Panel:',
+            style={'description_width': 'initial'}
+        )
+        
+        # Display button
+        self.display_button = widgets.Button(
+            description='Display Panel',
+            button_style='primary'
+        )
+        
+        # Export button
+        self.export_button = widgets.Button(
+            description='Export Code',
+            button_style='info'
+        )
+        
+        # Output area
+        self.output = widgets.Output()
+        
+        # Layout
+        self.controls = widgets.HBox([
+            self.panel_selector,
+            self.display_button,
+            self.export_button
+        ])
+        
+        self.widget = widgets.VBox([
+            self.controls,
+            self.output
+        ])
+    
+    def _setup_callbacks(self):
+        """Setup widget callbacks."""
+        self.display_button.on_click(self._on_display_click)
+        self.export_button.on_click(self._on_export_click)
+    
+    def _on_display_click(self, button):
+        """Display selected panel."""
+        with self.output:
+            self.output.clear_output()
+            panel_id = self.panel_selector.value
+            fig = self.dashboard.render_panel(panel_id)
+            fig.show()
+    
+    def _on_export_click(self, button):
+        """Export reproducible code."""
+        with self.output:
+            self.output.clear_output()
+            code = self.dashboard.export_code()
+            print("```python")
+            print(code)
+            print("```")
+    
+    def display(self):
+        """Display the widget."""
+        display(self.widget)
+```
+
+#### **1.2 Panel-Specific Widgets**
+```python
+# pysee/widgets/panel_widgets.py
+class UMAPWidget:
+    """Widget for UMAP panel configuration."""
+    
+    def __init__(self, panel):
+        self.panel = panel
+        self._create_controls()
+    
+    def _create_controls(self):
+        """Create UMAP-specific controls."""
+        self.embedding_dropdown = widgets.Dropdown(
+            options=['X_umap', 'X_tsne', 'X_pca'],
+            value='X_umap',
+            description='Embedding:'
+        )
+        
+        self.color_dropdown = widgets.Dropdown(
+            options=self.panel._data_wrapper.get_obs_columns(),
+            description='Color by:'
+        )
+        
+        self.opacity_slider = widgets.FloatSlider(
+            value=0.7,
+            min=0.1,
+            max=1.0,
+            step=0.1,
+            description='Opacity:'
+        )
+        
+        self.controls = widgets.VBox([
+            self.embedding_dropdown,
+            self.color_dropdown,
+            self.opacity_slider
+        ])
+```
+
+### **Phase 2: Advanced Widget Features (2-3 days)**
+**Priority: MEDIUM | Effort: 2-3 days | Impact: MEDIUM**
+
+#### **2.1 State Management**
+```python
+# pysee/widgets/state_manager.py
+class WidgetStateManager:
+    """Manage widget state persistence."""
+    
+    def __init__(self):
+        self.state = {}
+        self.callbacks = []
+    
+    def save_state(self, key, value):
+        """Save widget state."""
+        self.state[key] = value
+        self._notify_callbacks(key, value)
+    
+    def load_state(self, key, default=None):
+        """Load widget state."""
+        return self.state.get(key, default)
+    
+    def add_callback(self, callback):
+        """Add state change callback."""
+        self.callbacks.append(callback)
+    
+    def _notify_callbacks(self, key, value):
+        """Notify callbacks of state changes."""
+        for callback in self.callbacks:
+            callback(key, value)
+```
+
+#### **2.2 Interactive Configuration**
+```python
+# pysee/widgets/config_widget.py
+class ConfigWidget:
+    """Widget for panel configuration."""
+    
+    def __init__(self, panel):
+        self.panel = panel
+        self._create_config_controls()
+    
+    def _create_config_controls(self):
+        """Create configuration controls based on panel type."""
+        if isinstance(self.panel, UMAPPanel):
+            self._create_umap_controls()
+        elif isinstance(self.panel, ViolinPanel):
+            self._create_violin_controls()
+        # ... other panel types
+```
+
+### **Phase 3: Notebook-Specific Features (1-2 days)**
+**Priority: MEDIUM | Effort: 1-2 days | Impact: MEDIUM**
+
+#### **3.1 Magic Commands**
+```python
+# pysee/magic.py
+from IPython.core.magic import line_magic, cell_magic
+
+@line_magic
+def pysee(line):
+    """PySEE magic command for quick visualization."""
+    # Parse arguments
+    # Create dashboard
+    # Display widget
+    pass
+
+@cell_magic
+def pysee_panel(line, cell):
+    """PySEE panel magic for cell-based panel creation."""
+    # Execute cell code
+    # Create panel from result
+    # Display panel
+    pass
+```
+
+#### **3.2 Notebook Extensions**
+```python
+# pysee/nbextensions/pysee_extension.py
+def load_jupyter_server_extension(nbapp):
+    """Load PySEE Jupyter extension."""
+    # Register custom CSS
+    # Add keyboard shortcuts
+    # Enable auto-completion
+    pass
+```
+
+---
+
+## **🚀 Implementation Strategy**
+
+### **Step 1: Create Widget Infrastructure (Day 1)**
+1. Create `pysee/widgets/` directory
+2. Implement `PySEEWidget` base class
+3. Add basic panel selection and display
+4. Test in Jupyter notebook
+
+### **Step 2: Add Panel-Specific Widgets (Day 2)**
+1. Create widget classes for each panel type
+2. Add configuration controls
+3. Implement state management
+4. Add export functionality
+
+### **Step 3: Enhance User Experience (Day 3)**
+1. Add magic commands
+2. Create notebook examples
+3. Add documentation
+4. Test with real datasets
+
+---
+
+## **📋 Benefits for Scientific Users**
+
+### **✅ Improved Workflow:**
+- **Interactive Configuration**: No need to edit code for parameter changes
+- **Visual Feedback**: See changes immediately
+- **State Persistence**: Maintain configuration across notebook restarts
+- **Easy Sharing**: Widgets work in shared notebooks
+
+### **✅ Better Integration:**
+- **Seamless Experience**: Native Jupyter widget feel
+- **Keyboard Shortcuts**: Quick access to common functions
+- **Auto-completion**: IDE support for widget methods
+- **Error Handling**: Better error messages in notebook context
+
+### **✅ Scientific Use Cases:**
+- **Parameter Exploration**: Easily test different settings
+- **Collaborative Analysis**: Share interactive notebooks
+- **Teaching**: Better for educational purposes
+- **Documentation**: Self-documenting analysis workflows
+
+---
+
+## **🎯 Success Metrics**
+
+### **User Experience:**
+- [ ] Users can create dashboards with 3 clicks
+- [ ] Parameter changes are immediate
+- [ ] Widgets persist across notebook restarts
+- [ ] Export functionality works seamlessly
+
+### **Performance:**
+- [ ] Widget creation < 1 second
+- [ ] Panel rendering < 2 seconds
+- [ ] Memory usage < 100MB overhead
+- [ ] No blocking operations
+
+### **Adoption:**
+- [ ] 80% of users prefer widgets over code
+- [ ] 50% reduction in support questions
+- [ ] 30% increase in notebook usage
+- [ ] Positive feedback from scientific community
+
+---
+
+## **🔧 Technical Requirements**
+
+### **Dependencies:**
+```python
+# requirements.txt additions
+ipywidgets>=8.0.0
+ipython>=7.0.0
+jupyter>=1.0.0
+```
+
+### **File Structure:**
+```
+pysee/
+├── widgets/
+│   ├── __init__.py
+│   ├── dashboard_widget.py
+│   ├── panel_widgets.py
+│   ├── config_widget.py
+│   └── state_manager.py
+├── magic.py
+└── nbextensions/
+    └── pysee_extension.py
+```
+
+### **Testing:**
+- Unit tests for widget functionality
+- Integration tests with Jupyter
+- Performance benchmarks
+- User acceptance testing
+
+---
+
+## **💡 Recommendation**
+
+**YES, PySEE needs better Jupyter support!**
+
+**Why:**
+1. **Scientific Workflow**: Most bioinformatics work happens in Jupyter
+2. **User Experience**: Current `.show()` is too basic
+3. **Competitive Advantage**: Better than command-line alternatives
+4. **Adoption**: Easier adoption with interactive widgets
+
+**Priority: HIGH** - This should be the next major feature after DotPlot panel completion.
+
+**Timeline: 3-4 days total** - Can be done in parallel with other features.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0.0",
+    "pytest-timeout>=2.1.0",
     "black>=22.0.0",
     "flake8>=5.0.0",
     "mypy>=0.991",
@@ -96,4 +97,5 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-addopts = "-v --tb=short"
+addopts = "-v --tb=short --timeout=60"
+timeout = 60


### PR DESCRIPTION
##  CI Timeout Fix

### **Problem:**
- CI tests are hanging and causing timeouts
- Performance tests take too long and fail CI
- No timeout configuration for individual tests or jobs

### **Solution:**
- Add pytest-timeout plugin to dev dependencies
- Configure 60-second timeout for individual tests
- Add 10-minute timeout for CI jobs
- Update CI to run all tests with timeout and maxfail=3

### **Changes:**
- pyproject.toml: Added pytest-timeout dependency and timeout config
- .github/workflows/ci.yml: Added job timeout and test timeout flags

### **Expected Result:**
- CI tests will complete within 10 minutes
- Individual tests will timeout after 60 seconds
- No more hanging CI runs

**Type**: Bug Fix
**Priority**: High